### PR TITLE
Fix sequential requests in MenuForm

### DIFF
--- a/src/components/Admin/MenuForm.js
+++ b/src/components/Admin/MenuForm.js
@@ -82,7 +82,15 @@ const MenuForm = () => {
                 await axios.post(
                     "https://api.cloudinary.com/v1_1/dnomnqmne/image/upload",
                     formData
-                ).then(await axios.post(global.APIUrl + "/menuItem/addMenuItem", newItem)).then(await axios.put(global.APIUrl + "/inventoryItem/update", item));
+                );
+                await axios.post(
+                    global.APIUrl + "/menuItem/addMenuItem",
+                    newItem
+                );
+                await axios.put(
+                    global.APIUrl + "/inventoryItem/update",
+                    item
+                );
                 Swal.fire({
                     title: "Success!",
                     text: "Menu item added successfully.",


### PR DESCRIPTION
## Summary
- ensure async requests run sequentially when adding a menu item

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bad41681c8325813f81ed5590cfdc