### PR TITLE
Fix global API URL initialization

### DIFF
--- a/src/components/APIUrl.js
+++ b/src/components/APIUrl.js
@@ -1,2 +1,11 @@
-// global.APIUrl = 'http://localhost:5222';
-global.APIUrl = 'https://cafetaria-resturant.onrender.com';
+// local development URL
+// const API_URL = 'http://localhost:5222';
+
+// production URL
+const API_URL = 'https://cafetaria-resturant.onrender.com';
+
+// expose the API url on the global object so existing code can access it
+// `globalThis` works in both browser and Node environments
+globalThis.APIUrl = API_URL;
+
+export default API_URL;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+// initialise global API url
+import './components/APIUrl';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 


### PR DESCRIPTION
## Summary
- make APIUrl.js work in browser environments
- import APIUrl.js in index.js so the global variable is set on app load

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685babfde3648325b16c82a43d69aa24