### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/Customer/Feedback.js
+++ b/src/components/Customer/Feedback.js
@@ -38,6 +38,14 @@ const useStyles = makeStyles((theme) => ({
         marginBottom: theme.spacing(10),
         marginLeft: theme.spacing(30),
         marginRight: theme.spacing(30),
+        [theme.breakpoints.down('md')]: {
+            marginLeft: theme.spacing(10),
+            marginRight: theme.spacing(10),
+        },
+        [theme.breakpoints.down('sm')]: {
+            marginLeft: theme.spacing(2),
+            marginRight: theme.spacing(2),
+        },
     },
     card: {
         maxWidth: '100%',

--- a/src/components/Customer/HomePage.js
+++ b/src/components/Customer/HomePage.js
@@ -19,6 +19,9 @@ const useStyles = makeStyles((theme) => ({
   card: {
     maxWidth: 345,
     margin: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '100%',
+    },
   },
   media: {
     height: 200,
@@ -33,7 +36,13 @@ const useStyles = makeStyles((theme) => ({
   },
   carouselImage: {
     width: '100%',
-    height: '700px',
+    height: 700,
+    [theme.breakpoints.down('md')]: {
+      height: 400,
+    },
+    [theme.breakpoints.down('sm')]: {
+      height: 250,
+    },
   },
   arrow: {
     position: 'absolute',

--- a/src/components/Customer/Orders.js
+++ b/src/components/Customer/Orders.js
@@ -27,6 +27,14 @@ const useStyles = makeStyles((theme) => ({
         marginBottom: theme.spacing(10),
         marginLeft: theme.spacing(30),
         marginRight: theme.spacing(30),
+        [theme.breakpoints.down('md')]: {
+            marginLeft: theme.spacing(10),
+            marginRight: theme.spacing(10),
+        },
+        [theme.breakpoints.down('sm')]: {
+            marginLeft: theme.spacing(2),
+            marginRight: theme.spacing(2),
+        },
     },
     form: {
         marginTop: theme.spacing(3),

--- a/src/components/Customer/Support.js
+++ b/src/components/Customer/Support.js
@@ -27,6 +27,14 @@ const useStyles = makeStyles((theme) => ({
         marginBottom: theme.spacing(10),
         marginLeft: theme.spacing(30),
         marginRight: theme.spacing(30),
+        [theme.breakpoints.down('md')]: {
+            marginLeft: theme.spacing(10),
+            marginRight: theme.spacing(10),
+        },
+        [theme.breakpoints.down('sm')]: {
+            marginLeft: theme.spacing(2),
+            marginRight: theme.spacing(2),
+        },
     },
     form: {
         marginTop: theme.spacing(3),

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,24 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
 code {


### PR DESCRIPTION
## Summary
- make global styles responsive and hide extra scrollbars
- update homepage carousel and cards for breakpoints
- adjust feedback, orders and support page margins for small screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbaa633ac832583c5bf61ce002547