### PR TITLE
Add MUI theme toggling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,8 @@
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import { ThemeContextProvider, ThemeContext } from './ThemeContext';
+import { themes } from './theme';
 import SignUp from './components/Customer/SignUp';
 import LogIn from './components/Customer/Login';
 import AdminLogin from './components/Admin/AdminLogin';
@@ -31,16 +34,13 @@ import Customer from './components/Admin/Customer';
 
 
 function App() {
-  const theme = createTheme({
-    palette: {
-      primary: {
-        main: '#FFA500',
-      },
-    },
-  });
+  const { themeIndex } = React.useContext(ThemeContext);
+  const theme = themes[themeIndex];
+
   return (
-    <ThemeProvider theme={theme}>
-      <Router>
+    <ThemeContextProvider>
+      <ThemeProvider theme={theme}>
+        <Router>
         <Routes>
         <Route path="/OrderPaymentManage" element={<OrderPaymentManage />} />
         <Route path="/Customer" element={<Customer />} />
@@ -72,7 +72,8 @@ function App() {
         <Route path="/EmployeeLogin" element={<EmployeeLogin/>} />
         </Routes>
       </Router>
-    </ThemeProvider>
+      </ThemeProvider>
+    </ThemeContextProvider>
   );
 }
 

--- a/src/ThemeContext.js
+++ b/src/ThemeContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { themes } from './theme';
+
+export const ThemeContext = createContext({
+  themeIndex: 0,
+  toggleTheme: () => {},
+});
+
+export const ThemeContextProvider = ({ children }) => {
+  const [themeIndex, setThemeIndex] = useState(0);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('themeIndex');
+    if (saved !== null) {
+      setThemeIndex(parseInt(saved, 10));
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    setThemeIndex((prev) => {
+      const next = (prev + 1) % themes.length;
+      localStorage.setItem('themeIndex', next.toString());
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ themeIndex, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/components/Main/LogInNavbar.js
+++ b/src/components/Main/LogInNavbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppBar, Toolbar, Typography } from '@mui/material';
+import ThemeToggleButton from './ThemeToggleButton';
 import { Link } from 'react-router-dom';
 
 const Navbar = () => {
@@ -20,6 +21,7 @@ const Navbar = () => {
             <Link to={link.to} style={{ color: '#fff', textDecoration: 'none' }}>{link.label}</Link>
           </Typography>
         ))}
+        <ThemeToggleButton />
       </Toolbar>
     </AppBar>
   );

--- a/src/components/Main/NavBar.js
+++ b/src/components/Main/NavBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppBar, Toolbar, Typography } from '@mui/material';
+import ThemeToggleButton from './ThemeToggleButton';
 import { Link } from 'react-router-dom';
 
 const Navbar = () => {
@@ -29,6 +30,7 @@ const Navbar = () => {
             <Link to={link.to} style={{ color: '#fff', textDecoration: 'none' }}>{link.label}</Link>
           </Typography>
         ))}
+        <ThemeToggleButton />
         <Typography variant="subtitle1" sx={{ mr: 2 }}>
           <Link onClick={handleLogout} style={{ color: '#fff', textDecoration: 'none' }}>Log Out</Link>
         </Typography>

--- a/src/components/Main/ThemeToggleButton.js
+++ b/src/components/Main/ThemeToggleButton.js
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import IconButton from '@mui/material/IconButton';
+import ColorLensIcon from '@mui/icons-material/ColorLens';
+import Tooltip from '@mui/material/Tooltip';
+import { ThemeContext } from '../../ThemeContext';
+
+const ThemeToggleButton = () => {
+  const { toggleTheme } = useContext(ThemeContext);
+
+  return (
+    <Tooltip title="Change Theme">
+      <IconButton color="inherit" onClick={toggleTheme} data-testid="theme-toggle">
+        <ColorLensIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeToggleButton;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,32 @@
+import { createTheme } from '@mui/material/styles';
+
+export const themes = [
+  createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: '#FFA500' }, // orange
+      secondary: { main: '#f50057' },
+    },
+  }),
+  createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: '#2196F3' }, // blue
+      secondary: { main: '#f50057' },
+    },
+  }),
+  createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: '#4CAF50' }, // green
+      secondary: { main: '#f50057' },
+    },
+  }),
+  createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: '#9c27b0' }, // purple
+      secondary: { main: '#f50057' },
+    },
+  }),
+];


### PR DESCRIPTION
## Summary
- implement multiple MUI themes and context
- add a button to cycle themes in both navbars

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbdab9c5083258dc84e28b7dcb035