### PR TITLE
Refactor components to MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mui/icons-material": "^5.15.6",
     "@mui/lab": "*",
     "@mui/material": "^5.15.6",
+    "@mui/styles": "^5.15.6",
     "@mui/styled-engine-sc": "^6.0.0-alpha.13",
     "@mui/x-data-grid": "^6.19.2",
     "@testing-library/jest-dom": "^5.17.0",

--- a/src/components/Admin/AdminLogin.js
+++ b/src/components/Admin/AdminLogin.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useState } from 'react';
-import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, makeStyles, Link } from '@material-ui/core';
-import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, Link } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import axios from 'axios';
 import Swal from 'sweetalert2';
 

--- a/src/components/Admin/AdminSignUp.js
+++ b/src/components/Admin/AdminSignUp.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, makeStyles, Link } from '@material-ui/core';
+import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, Link } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import axios from 'axios';
-import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Swal from 'sweetalert2';
 
 

--- a/src/components/Admin/EmployeeLogin.js
+++ b/src/components/Admin/EmployeeLogin.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useState } from 'react';
-import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, makeStyles, Link } from '@material-ui/core';
-import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import { Avatar, Button, CssBaseline, TextField, Grid, Typography, Container, Card, CardContent, Link } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import axios from 'axios';
 import Swal from 'sweetalert2';
 

--- a/src/components/Customer/AboutUs.js
+++ b/src/components/Customer/AboutUs.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Card,
     CardContent,
     CardMedia,
     Grid,
     Typography
-} from '@material-ui/core';
+} from '@mui/material';
 import Navbar from '../Main/NavBar';
 import NavbarLog from '../Main/LogInNavbar';
 import Footer from '../Main/Footer';

--- a/src/components/Customer/CartPage.js
+++ b/src/components/Customer/CartPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
   Typography,
   Button,
@@ -10,8 +10,8 @@ import {
   CardContent,
   CardMedia,
   CardActions,
-} from '@material-ui/core';
-import DeleteIcon from '@material-ui/icons/Delete';
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import Navbar from '../Main/NavBar.js';
 import Footer from '../Main/Footer';
 

--- a/src/components/Customer/Checkout.js
+++ b/src/components/Customer/Checkout.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import { Button, Typography, Select, MenuItem, FormControl, InputLabel, Paper } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
+import { Button, Typography, Select, MenuItem, FormControl, InputLabel, Paper } from '@mui/material';
 import axios from 'axios';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/components/Customer/Feedback.js
+++ b/src/components/Customer/Feedback.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Card,
     CardContent,
@@ -12,10 +12,10 @@ import {
     ListItemText,
     Divider,
     Avatar
-} from '@material-ui/core';
+} from '@mui/material';
 import Navbar from '../Main/NavBar.js';
 import Footer from '../Main/Footer';
-import Rating from '@material-ui/lab/Rating';
+import Rating from '@mui/material/Rating';
 import axios from 'axios';
 import Swal from 'sweetalert2';
 

--- a/src/components/Customer/HomePage.js
+++ b/src/components/Customer/HomePage.js
@@ -2,11 +2,11 @@ import React, { useState, useEffect } from 'react';
 import Navbar from '../Main/NavBar';
 import NavbarLog from '../Main/LogInNavbar';
 import Footer from '../Main/Footer';
-import { makeStyles } from '@material-ui/core/styles';
-import { Typography, Card, CardActionArea, CardContent, CardMedia, Grid, IconButton } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
+import { Typography, Card, CardActionArea, CardContent, CardMedia, Grid, IconButton } from '@mui/material';
 import SwipeableViews from 'react-swipeable-views';
-import ArrowBackIcon from '@material-ui/icons/ArrowBack';
-import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/src/components/Customer/MenuPage.js
+++ b/src/components/Customer/MenuPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Card,
     CardContent,
@@ -9,10 +9,10 @@ import {
     Grid,
     IconButton,
     TextField,
-} from '@material-ui/core';
+} from '@mui/material';
 import axios from 'axios';
-import AddIcon from '@material-ui/icons/Add';
-import RemoveIcon from '@material-ui/icons/Remove';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import Navbar from '../Main/NavBar';
 import Footer from '../Main/Footer';
 import Swal from 'sweetalert2';

--- a/src/components/Customer/Orders.js
+++ b/src/components/Customer/Orders.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Typography,
     TextField,
     Button,
     Grid,
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper
-} from '@material-ui/core';
+} from '@mui/material';
 import Navbar from '../Main/NavBar.js';
 import Footer from '../Main/Footer';
 import axios from 'axios';

--- a/src/components/Customer/Profile.js
+++ b/src/components/Customer/Profile.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Typography,
     Grid,
@@ -9,10 +9,10 @@ import {
     Avatar,
     Modal,
     TextField,
-} from '@material-ui/core';
+} from '@mui/material';
 import Navbar from '../Main/NavBar.js';
 import Footer from '../Main/Footer';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import axios from 'axios';
 import Swal from 'sweetalert2';
 

--- a/src/components/Customer/Support.js
+++ b/src/components/Customer/Support.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@mui/styles';
 import {
     Typography,
     TextField,
     Button,
     Grid,
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper
-} from '@material-ui/core';
+} from '@mui/material';
 import Navbar from '../Main/NavBar.js';
 import Footer from '../Main/Footer';
 import axios from 'axios';

--- a/src/components/Main/Copyright.js
+++ b/src/components/Main/Copyright.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Link } from '@material-ui/core';
+import { Typography, Link } from '@mui/material';
 
 const Copyright = () => {
   return (

--- a/src/components/Main/Footer.js
+++ b/src/components/Main/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import { Grid, Typography, IconButton } from '@material-ui/core';
-import { Facebook, Twitter, Instagram, LocationOn, Email, Phone, Print } from '@material-ui/icons';
+import { makeStyles } from '@mui/styles';
+import { Grid, Typography, IconButton } from '@mui/material';
+import { Facebook, Twitter, Instagram, LocationOn, Email, Phone, Print } from '@mui/icons-material';
 import Logo from '../Images/Zperx.png';
 import { Link } from 'react-router-dom';
 import Copyright from '../Main/Copyright';


### PR DESCRIPTION
## Summary
- migrate Material UI imports from `@material-ui/*` to `@mui/*`
- add `@mui/styles` dependency for `makeStyles`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbe5f62a4832585df364b5142e733