### PR TITLE
Fix theme switching

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
-import { ThemeContextProvider, ThemeContext } from './ThemeContext';
+import { ThemeContext } from './ThemeContext';
 import { themes } from './theme';
 import SignUp from './components/Customer/SignUp';
 import LogIn from './components/Customer/Login';
@@ -38,8 +38,7 @@ function App() {
   const theme = themes[themeIndex];
 
   return (
-    <ThemeContextProvider>
-      <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme}>
         <Router>
         <Routes>
         <Route path="/OrderPaymentManage" element={<OrderPaymentManage />} />
@@ -73,7 +72,6 @@ function App() {
         </Routes>
       </Router>
       </ThemeProvider>
-    </ThemeContextProvider>
   );
 }
 

--- a/src/components/Customer/Login.js
+++ b/src/components/Customer/Login.js
@@ -9,7 +9,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+
 import Swal from 'sweetalert2';
 import axios from 'axios';
 import '../APIUrl'
@@ -17,7 +17,7 @@ import Footer from '../Main/Footer';
 import Navbar from '../Main/LogInNavbar';
 import Copyright from '../Main/Copyright';
 
-const defaultTheme = createTheme();
+
 
 export default function LogIn() {
     const quotes = ["“You can't connect the dots looking forward; you can only connect them looking backwards. So you have to trust that the dots will somehow connect in your future. You have to trust in something - your gut, destiny, life, karma, whatever. This approach has never let me down, and it has made all the difference in my life.” - Steve Jobs", "“Part of being a winner is knowing when enough is enough. Sometimes you have to give up the fight and walk away, and move on to something that’s more productive.” -Donald Trump", "“If you are hardworking and determined, you will make it and that’s the bottom line. I don’t believe in an easy way.” -Isabel dos Santos"]
@@ -102,7 +102,7 @@ export default function LogIn() {
 
 
     return (
-        <ThemeProvider theme={defaultTheme}>
+        <>
             <Navbar />
             <Grid container component="main" sx={{ height: '100vh' }}>
                 <CssBaseline />
@@ -241,6 +241,6 @@ export default function LogIn() {
                 </Grid>
             </Grid>
             <Footer />
-        </ThemeProvider>
+        </>
     );
 }

--- a/src/components/Customer/SignUp.js
+++ b/src/components/Customer/SignUp.js
@@ -9,7 +9,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+
 import Swal from 'sweetalert2';
 import axios from 'axios';
 import '../APIUrl';
@@ -18,7 +18,7 @@ import Navbar from '../Main/LogInNavbar';
 import Copyright from '../Main/Copyright';
 
 
-const defaultTheme = createTheme();
+
 
 export default function SignUpSide() {
     const quotes = ["“You can't connect the dots looking forward; you can only connect them looking backwards. So you have to trust that the dots will somehow connect in your future. You have to trust in something - your gut, destiny, life, karma, whatever. This approach has never let me down, and it has made all the difference in my life.” - Steve Jobs", "“Part of being a winner is knowing when enough is enough. Sometimes you have to give up the fight and walk away, and move on to something that’s more productive.” -Donald Trump", "“If you are hardworking and determined, you will make it and that’s the bottom line. I don’t believe in an easy way.” -Isabel dos Santos"];
@@ -116,7 +116,7 @@ export default function SignUpSide() {
     };
 
     return (
-        <ThemeProvider theme={defaultTheme}>
+        <>
             <Navbar />
             <Grid container component="main" sx={{ height: '100vh' }}>
                 <CssBaseline />
@@ -279,6 +279,6 @@ export default function SignUpSide() {
             <br />
             <br />
             <Footer />
-        </ThemeProvider>
+        </>
     );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,15 @@ import './index.css';
 // initialise global API url
 import './components/APIUrl';
 import App from './App';
+import { ThemeContextProvider } from './ThemeContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeContextProvider>
+      <App />
+    </ThemeContextProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- wrap the whole app in `ThemeContextProvider`
- remove individual `ThemeProvider`s
- use global provider for `Login` and `SignUp`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf290854832598f9bc126cc37897